### PR TITLE
🐛 fix: reorder glossary routes to fix popular endpoint

### DIFF
--- a/src/api/glossary_routes.py
+++ b/src/api/glossary_routes.py
@@ -62,31 +62,8 @@ async def get_terms(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/terms/{term_id}", response_model=GlossaryTermResponse)
-async def get_term_detail(term_id: str):
-    """용어 상세 조회"""
-    try:
-        term = glossary_service.get_term_by_id(term_id)
-        if not term:
-            raise HTTPException(status_code=404, detail="Term not found")
-
-        return GlossaryTermResponse(
-            id=str(term.id),
-            term_ko=term.term_ko,
-            term_en=term.term_en,
-            definition=term.definition,
-            example=term.example,
-            category=term.category,
-            difficulty_level=term.difficulty_level,
-            view_count=term.view_count,
-            is_ai_generated=term.is_ai_generated
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-
+# NOTE: Static routes must be defined BEFORE parameterized routes
+# to prevent FastAPI from matching "popular" as a term_id
 @router.get("/terms/popular", response_model=List[GlossaryTermResponse])
 async def get_popular_terms(
     limit: int = Query(10, ge=1, le=50)
@@ -108,6 +85,31 @@ async def get_popular_terms(
             )
             for term in terms
         ]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/terms/{term_id}", response_model=GlossaryTermResponse)
+async def get_term_detail(term_id: str):
+    """용어 상세 조회"""
+    try:
+        term = glossary_service.get_term_by_id(term_id)
+        if not term:
+            raise HTTPException(status_code=404, detail="Term not found")
+
+        return GlossaryTermResponse(
+            id=str(term.id),
+            term_ko=term.term_ko,
+            term_en=term.term_en,
+            definition=term.definition,
+            example=term.example,
+            category=term.category,
+            difficulty_level=term.difficulty_level,
+            view_count=term.view_count,
+            is_ai_generated=term.is_ai_generated
+        )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
## Summary
- Reorder FastAPI routes: `/terms/popular` before `/terms/{term_id}`
- Fixes 500 error where "popular" was interpreted as UUID

## Root Cause
FastAPI matches routes in definition order. The parameterized route
`/terms/{term_id}` was catching `/terms/popular` requests first.

## Test plan
- [x] Verify `/api/glossary/terms/popular` returns 200 with popular terms
- [x] Verify `/api/glossary/terms/{uuid}` still works for actual UUIDs

🤖 Generated with [Claude Code](https://claude.ai/code)