### PR TITLE
💄 Apply Toss-style light theme and Korean localization

### DIFF
--- a/components/layout/AppLayout.tsx
+++ b/components/layout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { User, Menu } from 'lucide-react';
 import Sidebar from '../Sidebar';
 import { useAuth } from '../../hooks/useAuth';
@@ -10,30 +10,43 @@ interface AppLayoutProps {
 
 const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const location = useLocation();
+  const navigate = useNavigate();
   const { logout } = useAuth();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login', { replace: true });
+  };
 
   const getPageTitle = () => {
     switch (location.pathname) {
       case '/':
-        return 'Dashboard';
+      case '/dashboard':
+        return '홈';
       case '/portfolio':
-        return 'Holdings';
+        return '내 주식';
+      case '/transactions':
+        return '거래 내역';
+      case '/notifications':
+        return '알림';
+      case '/rebalance':
+        return '리밸런싱';
       case '/analysis':
-        return 'Analytics';
+        return '자산 분석';
       case '/settings':
-        return 'Settings';
+        return '설정';
       case '/admin':
-        return 'Admin Console';
+        return '관리자';
       default:
-        return 'Dashboard';
+        return '홈';
     }
   };
 
   return (
-    <div className="min-h-screen bg-slate-900 text-slate-100 font-sans flex">
+    <div className="min-h-screen bg-toss-grey-100 text-toss-grey-900 font-sans flex">
       <Sidebar
-        onLogout={logout}
+        onLogout={handleLogout}
         isAdmin={true}
         isOpen={isSidebarOpen}
         onClose={() => setIsSidebarOpen(false)}
@@ -42,26 +55,26 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
       {/* Main Content Area */}
       <main className="flex-1 w-full md:ml-64 min-h-screen flex flex-col transition-all duration-300">
         {/* Header */}
-        <header className="h-16 bg-slate-900/80 backdrop-blur-md border-b border-slate-800 sticky top-0 z-40 px-4 md:px-8 flex items-center justify-between">
+        <header className="h-16 bg-white/80 backdrop-blur-md border-b border-toss-grey-200 sticky top-0 z-40 px-4 md:px-8 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <button
               onClick={() => setIsSidebarOpen(true)}
-              className="md:hidden p-2 -ml-2 hover:bg-slate-800 rounded-lg text-slate-400 transition-colors"
+              className="md:hidden p-2 -ml-2 hover:bg-toss-grey-200 rounded-lg text-toss-grey-500 transition-colors"
             >
               <Menu className="w-6 h-6" />
             </button>
-            <h2 className="text-xl font-bold text-white capitalize truncate">
+            <h2 className="text-xl font-bold text-toss-grey-900 truncate">
               {getPageTitle()}
             </h2>
           </div>
 
           <div className="flex items-center gap-3 md:gap-4">
             <div className="hidden md:flex flex-col items-end mr-2">
-              <span className="text-sm font-semibold text-white">John Doe</span>
-              <span className="text-xs text-slate-400">Premium User</span>
+              <span className="text-sm font-semibold text-toss-grey-900">사용자</span>
+              <span className="text-xs text-toss-grey-500">Premium User</span>
             </div>
-            <div className="w-9 h-9 md:w-10 md:h-10 rounded-full bg-slate-700 flex items-center justify-center border border-slate-600">
-              <User className="w-5 h-5 text-slate-300" />
+            <div className="w-9 h-9 md:w-10 md:h-10 rounded-full bg-toss-grey-200 flex items-center justify-center border border-toss-grey-300">
+              <User className="w-5 h-5 text-toss-grey-600" />
             </div>
           </div>
         </header>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -50,21 +50,21 @@ const Login: React.FC = () => {
       <div className="fixed bottom-[-10%] right-[-10%] w-[600px] h-[600px] bg-indigo-50 rounded-full blur-3xl opacity-50 pointer-events-none" />
 
       {/* Header / Brand Area */}
-      <header className="w-full max-w-7xl flex justify-between items-center z-10 mb-8 animate-fade-up">
+      <header className="fixed top-0 left-0 right-0 h-16 bg-white/80 backdrop-blur-md border-b border-toss-grey-200 z-50 px-4 md:px-8 flex items-center justify-between">
         <div className="flex items-center gap-2 cursor-pointer group" onClick={() => navigate('/')}>
            <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center text-white shadow-md group-hover:scale-105 transition-transform duration-300">
              <TrendingUp size={20} strokeWidth={3} />
            </div>
-           <span className="text-xl font-bold tracking-tight text-gray-900">Kabu Agent</span>
+           <span className="text-xl font-bold tracking-tight text-toss-grey-900">Kabu Agent</span>
         </div>
-        <nav className="hidden md:flex gap-6 text-sm font-medium text-gray-500">
-          <a href="#" className="hover:text-blue-600 transition-colors">고객센터</a>
-          <a href="#" className="hover:text-blue-600 transition-colors">이용안내</a>
+        <nav className="hidden md:flex gap-6 text-sm font-medium text-toss-grey-500">
+          <button onClick={() => alert('고객센터 서비스 준비 중입니다.')} className="hover:text-blue-600 transition-colors">고객센터</button>
+          <button onClick={() => alert('이용안내 페이지 준비 중입니다.')} className="hover:text-blue-600 transition-colors">이용안내</button>
         </nav>
       </header>
 
       {/* Main Content */}
-      <main className="w-full max-w-md z-10 flex-1 flex flex-col justify-center animate-fade-up" style={{ animationDelay: '0.1s' }}>
+      <main className="w-full max-w-md z-10 flex-1 flex flex-col justify-center pt-16 animate-fade-up" style={{ animationDelay: '0.1s' }}>
         
         {/* Login Card */}
         <div className="bg-white rounded-[32px] shadow-xl shadow-blue-900/5 p-8 md:p-10 border border-white/50 backdrop-blur-xl">
@@ -153,12 +153,12 @@ const Login: React.FC = () => {
             </button>
           </form>
 
-          <div className="mt-8 flex justify-center items-center gap-4 text-sm text-gray-500 font-medium">
-             <button type="button" className="hover:text-gray-800 transition-colors">아이디 찾기</button>
-             <div className="w-px h-3 bg-gray-300"></div>
-             <button type="button" className="hover:text-gray-800 transition-colors">비밀번호 재설정</button>
-             <div className="w-px h-3 bg-gray-300"></div>
-             <button type="button" onClick={() => navigate('/contact')} className="hover:text-gray-800 transition-colors">이용 문의</button>
+          <div className="mt-8 flex justify-center items-center gap-4 text-sm text-toss-grey-500 font-medium">
+             <button type="button" onClick={() => alert('아이디 찾기 기능은 준비 중입니다.')} className="hover:text-toss-grey-800 transition-colors">아이디 찾기</button>
+             <div className="w-px h-3 bg-toss-grey-300"></div>
+             <button type="button" onClick={() => alert('비밀번호 재설정 기능은 준비 중입니다.')} className="hover:text-toss-grey-800 transition-colors">비밀번호 재설정</button>
+             <div className="w-px h-3 bg-toss-grey-300"></div>
+             <button type="button" onClick={() => navigate('/contact')} className="hover:text-toss-grey-800 transition-colors">이용 문의</button>
           </div>
 
         </div>

--- a/src/widgets/app-layout/ui/AppLayout.tsx
+++ b/src/widgets/app-layout/ui/AppLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Sidebar } from '@widgets/sidebar';
 import { Header } from '@widgets/header';
 import { useAuthContext } from '@features/auth';
@@ -9,14 +10,20 @@ interface AppLayoutProps {
 
 export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const { logout, user } = useAuthContext();
+  const navigate = useNavigate();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   const isAdmin = user?.username === 'admin';
 
+  const handleLogout = () => {
+    logout();
+    navigate('/login', { replace: true });
+  };
+
   return (
-    <div className="min-h-screen bg-slate-900 text-slate-100 font-sans flex">
+    <div className="min-h-screen bg-toss-grey-100 text-toss-grey-900 font-sans flex">
       <Sidebar
-        onLogout={logout}
+        onLogout={handleLogout}
         isAdmin={isAdmin}
         isOpen={isSidebarOpen}
         onClose={() => setIsSidebarOpen(false)}

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -9,15 +9,15 @@ interface HeaderProps {
 }
 
 const pageTitles: Record<string, string> = {
-  '/': 'Dashboard',
-  '/dashboard': 'Dashboard',
-  '/portfolio': 'Holdings',
-  '/transactions': 'Transactions',
-  '/notifications': 'Notifications',
-  '/rebalance': 'Rebalancing',
-  '/analysis': 'Analytics',
-  '/settings': 'Settings',
-  '/admin': 'Admin Console',
+  '/': '홈',
+  '/dashboard': '홈',
+  '/portfolio': '내 주식',
+  '/transactions': '거래 내역',
+  '/notifications': '알림',
+  '/rebalance': '리밸런싱',
+  '/analysis': '자산 분석',
+  '/settings': '설정',
+  '/admin': '관리자',
 };
 
 export const Header: React.FC<HeaderProps> = ({
@@ -28,30 +28,30 @@ export const Header: React.FC<HeaderProps> = ({
   const location = useLocation();
 
   const getPageTitle = () => {
-    return pageTitles[location.pathname] || 'Dashboard';
+    return pageTitles[location.pathname] || '홈';
   };
 
   return (
-    <header className="h-16 bg-slate-900/80 backdrop-blur-md border-b border-slate-800 sticky top-0 z-40 px-4 md:px-8 flex items-center justify-between">
+    <header className="h-16 bg-white/80 backdrop-blur-md border-b border-toss-grey-200 sticky top-0 z-40 px-4 md:px-8 flex items-center justify-between">
       <div className="flex items-center gap-3">
         <button
           onClick={onMenuClick}
-          className="md:hidden p-2 -ml-2 hover:bg-slate-800 rounded-lg text-slate-400 transition-colors"
+          className="md:hidden p-2 -ml-2 hover:bg-toss-grey-200 rounded-lg text-toss-grey-500 transition-colors"
         >
           <Menu className="w-6 h-6" />
         </button>
-        <h2 className="text-xl font-bold text-white capitalize truncate">
+        <h2 className="text-xl font-bold text-toss-grey-900 truncate">
           {getPageTitle()}
         </h2>
       </div>
 
       <div className="flex items-center gap-3 md:gap-4">
         <div className="hidden md:flex flex-col items-end mr-2">
-          <span className="text-sm font-semibold text-white">{userName}</span>
-          <span className="text-xs text-slate-400">{userRole}</span>
+          <span className="text-sm font-semibold text-toss-grey-900">{userName}</span>
+          <span className="text-xs text-toss-grey-500">{userRole}</span>
         </div>
-        <div className="w-9 h-9 md:w-10 md:h-10 rounded-full bg-slate-700 flex items-center justify-center border border-slate-600">
-          <User className="w-5 h-5 text-slate-300" />
+        <div className="w-9 h-9 md:w-10 md:h-10 rounded-full bg-toss-grey-200 flex items-center justify-center border border-toss-grey-300">
+          <User className="w-5 h-5 text-toss-grey-600" />
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- 다크 테마(slate)에서 토스 스타일 라이트 테마(toss-grey)로 전환
- 영문 메뉴명을 한글로 번역 (Dashboard → 홈, Holdings → 내 주식 등)
- 로그아웃 시 로그인 페이지로 리다이렉트 기능 추가
- 로그인 페이지 헤더를 고정 스타일로 변경
- 미구현 기능에 placeholder alert 추가

## Changes
| File | Description |
|------|-------------|
| `components/layout/AppLayout.tsx` | Theme colors, Korean menu titles, logout redirect |
| `src/components/Login.tsx` | Fixed header, Korean text, placeholder alerts |
| `src/widgets/app-layout/ui/AppLayout.tsx` | Theme colors, logout redirect |
| `src/widgets/header/ui/Header.tsx` | Theme colors, Korean menu titles |

## Test plan
- [ ] 각 페이지에서 라이트 테마가 정상 적용되는지 확인
- [ ] 헤더의 메뉴명이 한글로 표시되는지 확인
- [ ] 로그아웃 시 로그인 페이지로 이동하는지 확인
- [ ] 로그인 페이지의 고정 헤더가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)