### PR TITLE
✨ feat: Add i18n internationalization support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, Suspense, lazy } from 'react';
-import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import Sidebar from './components/Sidebar';
 import { Menu } from 'lucide-react';
 import { AuthProvider, useAuth } from './src/contexts/AuthContext';
@@ -26,8 +26,14 @@ const PageLoader: React.FC = () => (
 
 const AppLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const location = useLocation();
+  const navigate = useNavigate();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const { user, logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
 
   const getPageTitle = () => {
     switch (location.pathname) {
@@ -43,7 +49,7 @@ const AppLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <div className="min-h-screen bg-toss-grey-100 text-toss-grey-900 font-sans flex">
       <Sidebar 
-        onLogout={logout} 
+        onLogout={handleLogout} 
         isAdmin={user?.username === 'admin'} 
         isOpen={isSidebarOpen}
         onClose={() => setIsSidebarOpen(false)}

--- a/components/common/LanguageSwitcher.tsx
+++ b/components/common/LanguageSwitcher.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Globe } from 'lucide-react';
+import { LANGUAGE_LABELS, SUPPORTED_LANGUAGES, SupportedLanguage } from '../../src/shared/i18n/config';
+
+export const LanguageSwitcher: React.FC<{ className?: string }> = ({ className = '' }) => {
+  const { i18n } = useTranslation();
+
+  const handleLanguageChange = (lang: SupportedLanguage) => {
+    i18n.changeLanguage(lang);
+    localStorage.setItem('language', lang);
+  };
+
+  const currentLang = (i18n.language?.split('-')[0] || 'ko') as SupportedLanguage;
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <div className="relative group">
+        <button 
+          className="flex items-center gap-2 px-3 py-2 rounded-full bg-toss-grey-100 hover:bg-toss-grey-200 transition-colors text-sm font-medium text-toss-grey-700"
+          aria-label="Change Language"
+        >
+          <Globe className="w-4 h-4" />
+          <span>{LANGUAGE_LABELS[currentLang] || 'Language'}</span>
+        </button>
+        
+        <div className="absolute right-0 top-full mt-2 w-32 py-2 bg-white rounded-xl shadow-lg border border-toss-grey-100 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 transform origin-top-right z-50">
+          {SUPPORTED_LANGUAGES.map((lang) => (
+            <button
+              key={lang}
+              onClick={() => handleLanguageChange(lang)}
+              className={`w-full px-4 py-2 text-left text-sm hover:bg-toss-grey-50 transition-colors ${
+                currentLang === lang ? 'text-toss-blue font-bold' : 'text-toss-grey-700'
+              }`}
+            >
+              {LANGUAGE_LABELS[lang]}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,12 @@
       "dependencies": {
         "@tanstack/react-query": "^5.90.11",
         "axios": "^1.13.2",
+        "i18next": "^25.7.4",
+        "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.554.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-i18next": "^16.5.1",
         "react-router-dom": "^7.9.6",
         "recharts": "^3.5.0",
         "web-vitals": "^5.1.0"
@@ -356,7 +359,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3720,6 +3722,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3746,6 +3757,46 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.7.4",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.7.4.tgz",
+      "integrity": "sha512-hRkpEblXXcXSNbw8mBNq9042OEetgyB/ahc/X17uV/khPwzV+uB8RHceHh3qavyrkPJvmXFKXME2Sy1E0KjAfw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/ignore": {
@@ -4787,6 +4838,33 @@
         "react": "^19.2.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.1.tgz",
+      "integrity": "sha512-Hks6UIRZWW4c+qDAnx1csVsCGYeIR4MoBGQgJ+NUoNnO6qLxXuf8zu0xdcinyXUORgGzCdRsexxO1Xzv3sTdnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
@@ -5301,7 +5379,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5566,6 +5644,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
   "dependencies": {
     "@tanstack/react-query": "^5.90.11",
     "axios": "^1.13.2",
+    "i18next": "^25.7.4",
+    "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.554.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-i18next": "^16.5.1",
     "react-router-dom": "^7.9.6",
     "recharts": "^3.5.0",
     "web-vitals": "^5.1.0"

--- a/public/locales/en/auth.json
+++ b/public/locales/en/auth.json
@@ -1,0 +1,30 @@
+{
+  "login": {
+    "title": "Hello",
+    "subtitle": "Welcome to Kabu Agent",
+    "username": "Username",
+    "password": "Password",
+    "usernamePlaceholder": "Enter your username",
+    "passwordPlaceholder": "Enter your password",
+    "submit": "Login",
+    "submitting": "Logging in...",
+    "demoHint": "Demo Account (Mock Data)"
+  },
+  "errors": {
+    "invalidCredentials": "Invalid username or password.",
+    "loginFailed": "Login failed. Please try again later."
+  },
+  "links": {
+    "findId": "Find ID",
+    "resetPassword": "Reset Password",
+    "contact": "Contact Us"
+  },
+  "footer": {
+    "agreement": "By logging in, you agree to our Terms of Service and Privacy Policy."
+  },
+  "contact": {
+    "title": "Contact Us",
+    "description": "Kabu Agent is currently a members-only service.",
+    "helpText": "If you wish to use our service, please contact us using the method below."
+  }
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,65 @@
+{
+  "app": {
+    "name": "Kabu Agent",
+    "tagline": "Safe and convenient asset management"
+  },
+  "navigation": {
+    "home": "Home",
+    "dashboard": "Dashboard",
+    "portfolio": "My Portfolio",
+    "transactions": "Transactions",
+    "notifications": "Notifications",
+    "rebalance": "Rebalancing",
+    "analysis": "Analysis",
+    "settings": "Settings",
+    "admin": "Admin"
+  },
+  "buttons": {
+    "submit": "Submit",
+    "cancel": "Cancel",
+    "save": "Save",
+    "close": "Close",
+    "retry": "Retry",
+    "back": "Back",
+    "login": "Login",
+    "logout": "Logout",
+    "startFree": "Start Free",
+    "markAllRead": "Mark All Read",
+    "add": "Add",
+    "viewAll": "View All",
+    "learnMore": "Learn More",
+    "backToHome": "Back to Home",
+    "connectionTest": "Connection Test",
+    "saveChanges": "Save Changes"
+  },
+  "labels": {
+    "loading": "Loading...",
+    "pageLoading": "Loading page...",
+    "noData": "No data available",
+    "search": "Search",
+    "filter": "Filter",
+    "all": "All",
+    "views": "views"
+  },
+  "time": {
+    "justNow": "Just now",
+    "minutesAgo": "{{count}} minutes ago",
+    "hoursAgo": "{{count}} hours ago",
+    "daysAgo": "{{count}} days ago"
+  },
+  "periods": {
+    "1W": "1W",
+    "1M": "1M",
+    "3M": "3M",
+    "6M": "6M",
+    "1Y": "1Y",
+    "ALL": "All"
+  },
+  "errors": {
+    "general": "An error occurred",
+    "network": "A network error occurred",
+    "notFound": "Page not found",
+    "unauthorized": "Login required",
+    "serverError": "Server error occurred. Please try again later."
+  }
+}

--- a/public/locales/en/glossary.json
+++ b/public/locales/en/glossary.json
@@ -1,0 +1,29 @@
+{
+  "title": "Investment Glossary",
+  "searchPlaceholder": "Search terms... (e.g., volatility, returns, P/E)",
+  "categories": {
+    "all": "All",
+    "risk": "Risk",
+    "returns": "Returns",
+    "sector": "Sector",
+    "market": "Market Indicators",
+    "trading": "Trading/Investment"
+  },
+  "difficulty": {
+    "all": "All",
+    "beginner": "Beginner",
+    "intermediate": "Intermediate",
+    "advanced": "Advanced"
+  },
+  "detail": {
+    "backToList": "Back to List",
+    "definition": "Definition",
+    "example": "Example"
+  },
+  "errors": {
+    "loadFailed": "Failed to load terms."
+  },
+  "empty": {
+    "noResults": "No results found."
+  }
+}

--- a/public/locales/en/landing.json
+++ b/public/locales/en/landing.json
@@ -1,0 +1,58 @@
+{
+  "hero": {
+    "title": "Manage your overseas stock portfolio",
+    "titleHighlight": "smartly with AI",
+    "subtitle": "Kabu Agent helps you navigate complex US stock investments.",
+    "description": "From real-time portfolio analysis to AI-powered news briefings, take your investments to the next level."
+  },
+  "features": {
+    "title": "Key Features",
+    "asset": {
+      "title": "Intuitive Asset Overview",
+      "description": "See your investment status at a glance. Visualize distribution by sector and stock."
+    },
+    "news": {
+      "title": "AI News Briefing",
+      "description": "AI summarizes complex foreign news for you. Never miss news that could impact your investments."
+    },
+    "security": {
+      "title": "Secure Investment Management",
+      "description": "Safely manage your assets with verified API integration."
+    }
+  },
+  "stockBasics": {
+    "title": "New to investing?",
+    "subtitle": "Start with the basics.",
+    "viewGuide": "View Full Guide",
+    "terms": {
+      "stock": {
+        "title": "Stock",
+        "description": "A security representing ownership in a company."
+      },
+      "dividend": {
+        "title": "Dividend",
+        "description": "A portion of profits paid by a company to its shareholders."
+      },
+      "etf": {
+        "title": "ETF",
+        "description": "A fund that bundles multiple assets and trades on an exchange."
+      },
+      "per": {
+        "title": "P/E Ratio",
+        "description": "Price divided by earnings per share, used for company valuation."
+      }
+    }
+  },
+  "market": {
+    "title": "Market Indices",
+    "updated": "Updated"
+  },
+  "news": {
+    "title": "Latest News",
+    "readMore": "Read More"
+  },
+  "footer": {
+    "copyright": "© 2024 Kabu Agent. All rights reserved.",
+    "disclaimer": "Investments carry risk, and you are responsible for your investment decisions."
+  }
+}

--- a/public/locales/en/nisa.json
+++ b/public/locales/en/nisa.json
@@ -1,0 +1,80 @@
+{
+  "title": "NISA (Nippon Individual Savings Account)",
+  "subtitle": "New NISA starting from 2024",
+  "description": "NISA is a tax-exempt investment system where investment gains are not taxed.",
+  "card": {
+    "title": "NISA Information",
+    "subtitle": "Tax-exempt investment system"
+  },
+  "limits": {
+    "title": "Investment Allowances and Limits",
+    "tsumitate": {
+      "title": "Tsumitate Investment Allowance",
+      "annual": "1.2 million yen/year",
+      "description": "Investment trusts suitable for long-term, regular, and diversified investment"
+    },
+    "growth": {
+      "title": "Growth Investment Allowance",
+      "annual": "2.4 million yen/year",
+      "description": "Listed stocks, investment trusts, etc."
+    },
+    "lifetime": {
+      "title": "Tax-exempt Holding Limit",
+      "amount": "18 million yen",
+      "description": "Up to 12 million yen for Growth Investment Allowance"
+    }
+  },
+  "features": {
+    "title": "Features of New NISA",
+    "unlimited": {
+      "title": "Unlimited Tax-exempt Period",
+      "description": "Holdings remain tax-exempt as long as they are not sold"
+    },
+    "reusable": {
+      "title": "Reusable Allowance",
+      "description": "Sold portions of the allowance can be reused from the following year"
+    },
+    "combined": {
+      "title": "Combined Use",
+      "description": "Tsumitate and Growth Investment Allowances can be used together"
+    }
+  },
+  "eligible": {
+    "title": "Eligible Products",
+    "tsumitate": {
+      "title": "Tsumitate Investment Allowance",
+      "items": [
+        "Investment trusts meeting FSA criteria",
+        "Low-cost products suitable for long-term investment"
+      ]
+    },
+    "growth": {
+      "title": "Growth Investment Allowance",
+      "items": [
+        "Listed stocks (domestic and foreign)",
+        "ETFs",
+        "REITs",
+        "Investment trusts"
+      ]
+    }
+  },
+  "faq": {
+    "title": "Frequently Asked Questions",
+    "items": [
+      {
+        "question": "Can I have multiple NISA accounts?",
+        "answer": "No, each person can only have one NISA account. However, you can change financial institutions on a yearly basis."
+      },
+      {
+        "question": "Can I buy foreign stocks with NISA?",
+        "answer": "Yes, you can purchase foreign listed stocks and ETFs with the Growth Investment Allowance. However, availability varies by securities company."
+      },
+      {
+        "question": "Are dividends also tax-exempt?",
+        "answer": "Yes, dividends from stocks held in a NISA account are also tax-exempt. However, they may be taxed depending on the dividend receiving method."
+      }
+    ]
+  },
+  "learnMore": "Learn More",
+  "disclaimer": "* This information is for reference only. Please confirm details with the FSA or your securities company."
+}

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -1,0 +1,36 @@
+{
+  "title": "Settings",
+  "language": {
+    "title": "Language Settings",
+    "description": "Select your preferred display language."
+  },
+  "kis": {
+    "title": "KIS API Settings",
+    "accountNumber": "Account Number"
+  },
+  "display": {
+    "title": "Display Settings",
+    "currency": "Default Currency",
+    "refreshInterval": "Refresh Interval",
+    "intervals": {
+      "realtime": "Real-time",
+      "1min": "1 minute",
+      "5min": "5 minutes"
+    }
+  },
+  "messages": {
+    "saved": "Settings saved successfully."
+  },
+  "notifications": {
+    "title": "Notification Center",
+    "tabs": {
+      "notifications": "Notifications",
+      "priceAlerts": "Price Alerts"
+    },
+    "addAlert": "Add Alert",
+    "empty": {
+      "title": "No notifications",
+      "description": "New notifications will appear here"
+    }
+  }
+}

--- a/public/locales/ja/auth.json
+++ b/public/locales/ja/auth.json
@@ -1,0 +1,30 @@
+{
+  "login": {
+    "title": "こんにちは",
+    "subtitle": "Kabu Agentです",
+    "username": "ユーザーID",
+    "password": "パスワード",
+    "usernamePlaceholder": "ユーザーIDを入力してください",
+    "passwordPlaceholder": "パスワードを入力してください",
+    "submit": "ログイン",
+    "submitting": "ログイン中...",
+    "demoHint": "Demo Account (Mock Data)"
+  },
+  "errors": {
+    "invalidCredentials": "ユーザーIDまたはパスワードが正しくありません。",
+    "loginFailed": "ログインに失敗しました。後でもう一度お試しください。"
+  },
+  "links": {
+    "findId": "ID確認",
+    "resetPassword": "パスワード再設定",
+    "contact": "お問い合わせ"
+  },
+  "footer": {
+    "agreement": "ログインすると、利用規約およびプライバシーポリシーに同意したものとみなされます。"
+  },
+  "contact": {
+    "title": "お問い合わせ",
+    "description": "現在Kabu Agentは会員制で運営されています。",
+    "helpText": "サービスのご利用をご希望の場合は、以下の方法でお問い合わせください。"
+  }
+}

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -1,0 +1,65 @@
+{
+  "app": {
+    "name": "Kabu Agent",
+    "tagline": "安全で便利な資産管理"
+  },
+  "navigation": {
+    "home": "ホーム",
+    "dashboard": "ダッシュボード",
+    "portfolio": "マイ株式",
+    "transactions": "取引履歴",
+    "notifications": "通知",
+    "rebalance": "リバランス",
+    "analysis": "資産分析",
+    "settings": "設定",
+    "admin": "管理者"
+  },
+  "buttons": {
+    "submit": "送信",
+    "cancel": "キャンセル",
+    "save": "保存",
+    "close": "閉じる",
+    "retry": "再試行",
+    "back": "戻る",
+    "login": "ログイン",
+    "logout": "ログアウト",
+    "startFree": "無料で始める",
+    "markAllRead": "すべて既読",
+    "add": "追加",
+    "viewAll": "すべて表示",
+    "learnMore": "詳しく見る",
+    "backToHome": "ホームに戻る",
+    "connectionTest": "接続テスト",
+    "saveChanges": "変更を保存"
+  },
+  "labels": {
+    "loading": "読み込み中...",
+    "pageLoading": "ページを読み込み中...",
+    "noData": "データがありません",
+    "search": "検索",
+    "filter": "フィルター",
+    "all": "すべて",
+    "views": "閲覧"
+  },
+  "time": {
+    "justNow": "たった今",
+    "minutesAgo": "{{count}}分前",
+    "hoursAgo": "{{count}}時間前",
+    "daysAgo": "{{count}}日前"
+  },
+  "periods": {
+    "1W": "1週間",
+    "1M": "1ヶ月",
+    "3M": "3ヶ月",
+    "6M": "6ヶ月",
+    "1Y": "1年",
+    "ALL": "全期間"
+  },
+  "errors": {
+    "general": "エラーが発生しました",
+    "network": "ネットワークエラーが発生しました",
+    "notFound": "ページが見つかりません",
+    "unauthorized": "ログインが必要です",
+    "serverError": "サーバーエラーが発生しました。しばらくしてから再度お試しください。"
+  }
+}

--- a/public/locales/ja/glossary.json
+++ b/public/locales/ja/glossary.json
@@ -1,0 +1,29 @@
+{
+  "title": "投資用語ガイド",
+  "searchPlaceholder": "用語検索... (例: ボラティリティ、利回り、PER)",
+  "categories": {
+    "all": "すべて",
+    "risk": "リスク",
+    "returns": "利回り",
+    "sector": "セクター",
+    "market": "市場指標",
+    "trading": "取引/投資"
+  },
+  "difficulty": {
+    "all": "すべて",
+    "beginner": "初級",
+    "intermediate": "中級",
+    "advanced": "上級"
+  },
+  "detail": {
+    "backToList": "一覧に戻る",
+    "definition": "定義",
+    "example": "例"
+  },
+  "errors": {
+    "loadFailed": "用語の読み込みに失敗しました。"
+  },
+  "empty": {
+    "noResults": "検索結果がありません。"
+  }
+}

--- a/public/locales/ja/landing.json
+++ b/public/locales/ja/landing.json
@@ -1,0 +1,58 @@
+{
+  "hero": {
+    "title": "海外株式ポートフォリオを",
+    "titleHighlight": "AIとスマートに管理しましょう",
+    "subtitle": "複雑な米国株投資、Kabu Agentがお手伝いします。",
+    "description": "リアルタイムポートフォリオ分析からAIベースのニュースブリーフィングまで、あなたの投資をワンランクアップ。"
+  },
+  "features": {
+    "title": "主な機能",
+    "asset": {
+      "title": "直感的な資産状況",
+      "description": "一目で分かる投資状況。セクター別、銘柄別の分布を視覚的に確認できます。"
+    },
+    "news": {
+      "title": "AIニュースブリーフィング",
+      "description": "複雑な海外ニュースをAIが要約。投資に影響を与えるニュースを見逃しません。"
+    },
+    "security": {
+      "title": "安全な投資管理",
+      "description": "検証済みのAPI連携で安全に資産を管理できます。"
+    }
+  },
+  "stockBasics": {
+    "title": "投資が初めてですか？",
+    "subtitle": "基本用語から始めましょう。",
+    "viewGuide": "ガイドを見る",
+    "terms": {
+      "stock": {
+        "title": "株式",
+        "description": "会社の所有権を表す有価証券です。"
+      },
+      "dividend": {
+        "title": "配当金",
+        "description": "会社が株主に支払う利益の一部です。"
+      },
+      "etf": {
+        "title": "ETF",
+        "description": "複数の資産をまとめて取引所で取引されるファンドです。"
+      },
+      "per": {
+        "title": "PER",
+        "description": "株価を1株当たり利益で割った値で、企業価値評価に使用されます。"
+      }
+    }
+  },
+  "market": {
+    "title": "主要指数",
+    "updated": "更新"
+  },
+  "news": {
+    "title": "最新ニュース",
+    "readMore": "続きを読む"
+  },
+  "footer": {
+    "copyright": "© 2024 Kabu Agent. All rights reserved.",
+    "disclaimer": "投資にはリスクが伴い、投資結果の責任はご本人にあります。"
+  }
+}

--- a/public/locales/ja/nisa.json
+++ b/public/locales/ja/nisa.json
@@ -1,0 +1,80 @@
+{
+  "title": "NISA（少額投資非課税制度）",
+  "subtitle": "2024年から始まる新NISA",
+  "description": "NISAは、投資で得た利益が非課税になる制度です。",
+  "card": {
+    "title": "NISA情報",
+    "subtitle": "非課税投資制度"
+  },
+  "limits": {
+    "title": "投資枠と限度額",
+    "tsumitate": {
+      "title": "つみたて投資枠",
+      "annual": "年間120万円",
+      "description": "長期・積立・分散投資に適した投資信託"
+    },
+    "growth": {
+      "title": "成長投資枠",
+      "annual": "年間240万円",
+      "description": "上場株式・投資信託等"
+    },
+    "lifetime": {
+      "title": "非課税保有限度額",
+      "amount": "1,800万円",
+      "description": "うち成長投資枠は1,200万円まで"
+    }
+  },
+  "features": {
+    "title": "新NISAの特徴",
+    "unlimited": {
+      "title": "非課税期間無期限",
+      "description": "売却しない限り、非課税のまま保有できます"
+    },
+    "reusable": {
+      "title": "枠の再利用",
+      "description": "売却した分の枠は翌年以降に再利用可能"
+    },
+    "combined": {
+      "title": "併用可能",
+      "description": "つみたて投資枠と成長投資枠は併用できます"
+    }
+  },
+  "eligible": {
+    "title": "投資対象商品",
+    "tsumitate": {
+      "title": "つみたて投資枠",
+      "items": [
+        "金融庁が定めた基準を満たす投資信託",
+        "低コストで長期投資に適した商品"
+      ]
+    },
+    "growth": {
+      "title": "成長投資枠",
+      "items": [
+        "上場株式（国内・海外）",
+        "ETF",
+        "REIT",
+        "投資信託"
+      ]
+    }
+  },
+  "faq": {
+    "title": "よくある質問",
+    "items": [
+      {
+        "question": "NISAの口座は複数作れますか？",
+        "answer": "いいえ、NISA口座は1人1口座のみです。ただし、金融機関の変更は年単位で可能です。"
+      },
+      {
+        "question": "外国株式もNISAで購入できますか？",
+        "answer": "はい、成長投資枠で海外上場株式やETFを購入できます。ただし、取扱いは証券会社によって異なります。"
+      },
+      {
+        "question": "配当金も非課税ですか？",
+        "answer": "はい、NISA口座で保有する株式の配当金も非課税です。ただし、配当金の受取方法によっては課税される場合があります。"
+      }
+    ]
+  },
+  "learnMore": "詳しく見る",
+  "disclaimer": "※ 本情報は参考情報です。詳細は金融庁や証券会社にご確認ください。"
+}

--- a/public/locales/ja/settings.json
+++ b/public/locales/ja/settings.json
@@ -1,0 +1,36 @@
+{
+  "title": "設定",
+  "language": {
+    "title": "言語設定",
+    "description": "アプリの表示言語を選択してください。"
+  },
+  "kis": {
+    "title": "KIS API設定",
+    "accountNumber": "口座番号"
+  },
+  "display": {
+    "title": "表示設定",
+    "currency": "デフォルト通貨",
+    "refreshInterval": "更新間隔",
+    "intervals": {
+      "realtime": "リアルタイム",
+      "1min": "1分",
+      "5min": "5分"
+    }
+  },
+  "messages": {
+    "saved": "設定が安全に保存されました。"
+  },
+  "notifications": {
+    "title": "通知センター",
+    "tabs": {
+      "notifications": "通知",
+      "priceAlerts": "価格アラート"
+    },
+    "addAlert": "アラート追加",
+    "empty": {
+      "title": "通知がありません",
+      "description": "新しい通知があればここに表示されます"
+    }
+  }
+}

--- a/public/locales/ko/auth.json
+++ b/public/locales/ko/auth.json
@@ -1,0 +1,30 @@
+{
+  "login": {
+    "title": "안녕하세요",
+    "subtitle": "Kabu Agent 입니다",
+    "username": "아이디",
+    "password": "비밀번호",
+    "usernamePlaceholder": "아이디를 입력해주세요",
+    "passwordPlaceholder": "비밀번호를 입력해주세요",
+    "submit": "로그인",
+    "submitting": "로그인 중...",
+    "demoHint": "Demo Account (Mock Data)"
+  },
+  "errors": {
+    "invalidCredentials": "아이디 또는 비밀번호가 올바르지 않습니다.",
+    "loginFailed": "로그인에 실패했습니다. 나중에 다시 시도해주세요."
+  },
+  "links": {
+    "findId": "아이디 찾기",
+    "resetPassword": "비밀번호 재설정",
+    "contact": "이용 문의"
+  },
+  "footer": {
+    "agreement": "로그인하시면 서비스 이용약관 및 개인정보처리방침에 동의하는 것으로 간주됩니다."
+  },
+  "contact": {
+    "title": "이용 문의",
+    "description": "현재 Kabu Agent는 회원제로 운영되고 있습니다.",
+    "helpText": "서비스 이용을 원하시면 아래 방법으로 문의해 주세요."
+  }
+}

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -1,0 +1,65 @@
+{
+  "app": {
+    "name": "Kabu Agent",
+    "tagline": "안전하고 편리한 자산 관리"
+  },
+  "navigation": {
+    "home": "홈",
+    "dashboard": "대시보드",
+    "portfolio": "내 주식",
+    "transactions": "거래 내역",
+    "notifications": "알림",
+    "rebalance": "리밸런싱",
+    "analysis": "자산 분석",
+    "settings": "설정",
+    "admin": "관리자"
+  },
+  "buttons": {
+    "submit": "제출",
+    "cancel": "취소",
+    "save": "저장",
+    "close": "닫기",
+    "retry": "다시 시도",
+    "back": "뒤로",
+    "login": "로그인",
+    "logout": "로그아웃",
+    "startFree": "무료로 시작하기",
+    "markAllRead": "모두 읽음",
+    "add": "추가",
+    "viewAll": "전체 보기",
+    "learnMore": "자세히 보기",
+    "backToHome": "메인으로 돌아가기",
+    "connectionTest": "연결 테스트",
+    "saveChanges": "변경사항 저장"
+  },
+  "labels": {
+    "loading": "로딩 중...",
+    "pageLoading": "페이지 로딩 중...",
+    "noData": "데이터가 없습니다",
+    "search": "검색",
+    "filter": "필터",
+    "all": "전체",
+    "views": "조회"
+  },
+  "time": {
+    "justNow": "방금 전",
+    "minutesAgo": "{{count}}분 전",
+    "hoursAgo": "{{count}}시간 전",
+    "daysAgo": "{{count}}일 전"
+  },
+  "periods": {
+    "1W": "1주",
+    "1M": "1개월",
+    "3M": "3개월",
+    "6M": "6개월",
+    "1Y": "1년",
+    "ALL": "전체"
+  },
+  "errors": {
+    "general": "오류가 발생했습니다",
+    "network": "네트워크 오류가 발생했습니다",
+    "notFound": "페이지를 찾을 수 없습니다",
+    "unauthorized": "로그인이 필요합니다",
+    "serverError": "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+  }
+}

--- a/public/locales/ko/glossary.json
+++ b/public/locales/ko/glossary.json
@@ -1,0 +1,29 @@
+{
+  "title": "투자 용어 가이드",
+  "searchPlaceholder": "용어 검색... (예: 변동성, 수익률, PER)",
+  "categories": {
+    "all": "전체",
+    "risk": "리스크",
+    "returns": "수익률",
+    "sector": "섹터",
+    "market": "시장 지표",
+    "trading": "거래/투자"
+  },
+  "difficulty": {
+    "all": "전체",
+    "beginner": "초급",
+    "intermediate": "중급",
+    "advanced": "고급"
+  },
+  "detail": {
+    "backToList": "목록으로 돌아가기",
+    "definition": "정의",
+    "example": "예시"
+  },
+  "errors": {
+    "loadFailed": "용어를 불러오는데 실패했습니다."
+  },
+  "empty": {
+    "noResults": "검색 결과가 없습니다."
+  }
+}

--- a/public/locales/ko/landing.json
+++ b/public/locales/ko/landing.json
@@ -1,0 +1,58 @@
+{
+  "hero": {
+    "title": "해외주식 포트폴리오,",
+    "titleHighlight": "AI와 함께 스마트하게 관리하세요",
+    "subtitle": "복잡한 미국 주식 투자, Kabu Agent가 도와드립니다.",
+    "description": "실시간 포트폴리오 분석부터 AI 기반 뉴스 브리핑까지, 당신의 투자를 한 단계 업그레이드하세요."
+  },
+  "features": {
+    "title": "주요 기능",
+    "asset": {
+      "title": "직관적인 자산 현황",
+      "description": "한눈에 파악하는 나의 투자 현황. 섹터별, 종목별 분포를 시각적으로 확인하세요."
+    },
+    "news": {
+      "title": "AI 뉴스 브리핑",
+      "description": "복잡한 해외 뉴스, AI가 핵심만 요약해드립니다. 투자에 영향을 줄 소식을 놓치지 마세요."
+    },
+    "security": {
+      "title": "안전한 투자 관리",
+      "description": "검증된 한국투자증권 API 연동으로 안전하게 자산을 관리하세요."
+    }
+  },
+  "stockBasics": {
+    "title": "투자가 처음이신가요?",
+    "subtitle": "핵심 용어부터 시작해보세요.",
+    "viewGuide": "전체 가이드 보기",
+    "terms": {
+      "stock": {
+        "title": "주식",
+        "description": "회사의 소유권을 나타내는 증권입니다."
+      },
+      "dividend": {
+        "title": "배당금",
+        "description": "회사가 주주에게 지급하는 이익의 일부입니다."
+      },
+      "etf": {
+        "title": "ETF",
+        "description": "여러 자산을 묶어 거래소에서 거래되는 펀드입니다."
+      },
+      "per": {
+        "title": "PER",
+        "description": "주가를 주당순이익으로 나눈 값으로, 기업 가치 평가에 사용됩니다."
+      }
+    }
+  },
+  "market": {
+    "title": "주요 지수",
+    "updated": "업데이트"
+  },
+  "news": {
+    "title": "최신 뉴스",
+    "readMore": "더 읽기"
+  },
+  "footer": {
+    "copyright": "© 2024 Kabu Agent. All rights reserved.",
+    "disclaimer": "투자에는 위험이 따르며, 투자 결과에 대한 책임은 본인에게 있습니다."
+  }
+}

--- a/public/locales/ko/settings.json
+++ b/public/locales/ko/settings.json
@@ -1,0 +1,36 @@
+{
+  "title": "설정",
+  "language": {
+    "title": "언어 설정",
+    "description": "앱 표시 언어를 선택하세요."
+  },
+  "kis": {
+    "title": "KIS API 설정",
+    "accountNumber": "계좌번호"
+  },
+  "display": {
+    "title": "화면 설정",
+    "currency": "기본 통화",
+    "refreshInterval": "새로고침 주기",
+    "intervals": {
+      "realtime": "실시간",
+      "1min": "1분",
+      "5min": "5분"
+    }
+  },
+  "messages": {
+    "saved": "설정이 안전하게 저장되었습니다."
+  },
+  "notifications": {
+    "title": "알림 센터",
+    "tabs": {
+      "notifications": "알림",
+      "priceAlerts": "가격 알림"
+    },
+    "addAlert": "알림 추가",
+    "empty": {
+      "title": "알림이 없습니다",
+      "description": "새로운 알림이 오면 여기에 표시됩니다"
+    }
+  }
+}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { QueryProvider, AuthProvider } from './providers';
+import { I18nProvider } from '@shared/i18n';
 import { AppRouter } from './router';
 
 export const App: React.FC = () => {
   return (
-    <QueryProvider>
-      <AuthProvider>
-        <AppRouter />
-      </AuthProvider>
-    </QueryProvider>
+    <I18nProvider>
+      <QueryProvider>
+        <AuthProvider>
+          <AppRouter />
+        </AuthProvider>
+      </QueryProvider>
+    </I18nProvider>
   );
 };
 

--- a/src/shared/i18n/config.ts
+++ b/src/shared/i18n/config.ts
@@ -1,0 +1,94 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+export const SUPPORTED_LANGUAGES = ['ko', 'ja', 'en'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const DEFAULT_LANGUAGE: SupportedLanguage = 'ko';
+
+export const LANGUAGE_LABELS: Record<SupportedLanguage, string> = {
+  ko: '한국어',
+  ja: '日本語',
+  en: 'English',
+};
+
+export const LOCALE_MAP: Record<SupportedLanguage, string> = {
+  ko: 'ko-KR',
+  ja: 'ja-JP',
+  en: 'en-US',
+};
+
+// Import translation files directly for bundling
+import commonKo from '../../../public/locales/ko/common.json';
+import authKo from '../../../public/locales/ko/auth.json';
+import landingKo from '../../../public/locales/ko/landing.json';
+import glossaryKo from '../../../public/locales/ko/glossary.json';
+import settingsKo from '../../../public/locales/ko/settings.json';
+
+import commonJa from '../../../public/locales/ja/common.json';
+import authJa from '../../../public/locales/ja/auth.json';
+import landingJa from '../../../public/locales/ja/landing.json';
+import glossaryJa from '../../../public/locales/ja/glossary.json';
+import settingsJa from '../../../public/locales/ja/settings.json';
+import nisaJa from '../../../public/locales/ja/nisa.json';
+
+import commonEn from '../../../public/locales/en/common.json';
+import authEn from '../../../public/locales/en/auth.json';
+import landingEn from '../../../public/locales/en/landing.json';
+import glossaryEn from '../../../public/locales/en/glossary.json';
+import settingsEn from '../../../public/locales/en/settings.json';
+import nisaEn from '../../../public/locales/en/nisa.json';
+
+const resources = {
+  ko: {
+    common: commonKo,
+    auth: authKo,
+    landing: landingKo,
+    glossary: glossaryKo,
+    settings: settingsKo,
+  },
+  ja: {
+    common: commonJa,
+    auth: authJa,
+    landing: landingJa,
+    glossary: glossaryJa,
+    settings: settingsJa,
+    nisa: nisaJa,
+  },
+  en: {
+    common: commonEn,
+    auth: authEn,
+    landing: landingEn,
+    glossary: glossaryEn,
+    settings: settingsEn,
+    nisa: nisaEn,
+  },
+};
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    supportedLngs: SUPPORTED_LANGUAGES as unknown as string[],
+    fallbackLng: DEFAULT_LANGUAGE,
+    defaultNS: 'common',
+    ns: ['common', 'auth', 'landing', 'glossary', 'settings', 'nisa'],
+
+    detection: {
+      order: ['localStorage', 'navigator', 'htmlTag'],
+      lookupLocalStorage: 'language',
+      caches: ['localStorage'],
+    },
+
+    interpolation: {
+      escapeValue: false,
+    },
+
+    react: {
+      useSuspense: true,
+    },
+  });
+
+export default i18n;

--- a/src/shared/i18n/hooks/useLanguage.ts
+++ b/src/shared/i18n/hooks/useLanguage.ts
@@ -1,0 +1,35 @@
+import { useTranslation } from 'react-i18next';
+import { useCallback } from 'react';
+import type { SupportedLanguage } from '../types';
+import { SUPPORTED_LANGUAGES, LANGUAGE_LABELS, LOCALE_MAP } from '../config';
+
+export const useLanguage = () => {
+  const { i18n } = useTranslation();
+
+  const currentLanguage = (i18n.language?.split('-')[0] ||
+    'ko') as SupportedLanguage;
+
+  const changeLanguage = useCallback(
+    async (lng: SupportedLanguage) => {
+      await i18n.changeLanguage(lng);
+      localStorage.setItem('language', lng);
+      document.documentElement.lang = lng;
+    },
+    [i18n]
+  );
+
+  const isJapanese = currentLanguage === 'ja';
+
+  const getLocale = useCallback(() => {
+    return LOCALE_MAP[currentLanguage] || LOCALE_MAP.ko;
+  }, [currentLanguage]);
+
+  return {
+    currentLanguage,
+    changeLanguage,
+    supportedLanguages: SUPPORTED_LANGUAGES,
+    languageLabels: LANGUAGE_LABELS,
+    isJapanese,
+    getLocale,
+  };
+};

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -1,0 +1,11 @@
+export { default as i18n } from './config';
+export {
+  SUPPORTED_LANGUAGES,
+  DEFAULT_LANGUAGE,
+  LANGUAGE_LABELS,
+  LOCALE_MAP,
+  type SupportedLanguage,
+} from './config';
+export { useLanguage } from './hooks/useLanguage';
+export { I18nProvider } from './providers/I18nProvider';
+export { LANGUAGE_OPTIONS, type LanguageOption } from './types';

--- a/src/shared/i18n/providers/I18nProvider.tsx
+++ b/src/shared/i18n/providers/I18nProvider.tsx
@@ -1,0 +1,31 @@
+import React, { Suspense, useEffect } from 'react';
+import { I18nextProvider, useTranslation } from 'react-i18next';
+import i18n from '../config';
+import { LoadingSpinner } from '@shared/ui';
+
+interface I18nProviderProps {
+  children: React.ReactNode;
+}
+
+const LanguageInitializer: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    // Set document lang attribute on language change
+    document.documentElement.lang = i18n.language?.split('-')[0] || 'ko';
+  }, [i18n.language]);
+
+  return <>{children}</>;
+};
+
+export const I18nProvider: React.FC<I18nProviderProps> = ({ children }) => {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <Suspense fallback={<LoadingSpinner />}>
+        <LanguageInitializer>{children}</LanguageInitializer>
+      </Suspense>
+    </I18nextProvider>
+  );
+};

--- a/src/shared/i18n/types.ts
+++ b/src/shared/i18n/types.ts
@@ -1,0 +1,15 @@
+import type { SUPPORTED_LANGUAGES } from './config';
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export interface LanguageOption {
+  code: SupportedLanguage;
+  label: string;
+  nativeName: string;
+}
+
+export const LANGUAGE_OPTIONS: LanguageOption[] = [
+  { code: 'ko', label: 'Korean', nativeName: '한국어' },
+  { code: 'ja', label: 'Japanese', nativeName: '日本語' },
+  { code: 'en', label: 'English', nativeName: 'English' },
+];

--- a/src/shared/ui/LanguageSelector.tsx
+++ b/src/shared/ui/LanguageSelector.tsx
@@ -1,0 +1,86 @@
+/**
+ * Language Selector Component
+ */
+import React from 'react';
+import { Globe } from 'lucide-react';
+import { useLanguage } from '@shared/i18n';
+
+interface LanguageSelectorProps {
+  variant?: 'dropdown' | 'buttons';
+  showIcon?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeClasses = {
+  sm: 'text-xs px-2 py-1',
+  md: 'text-sm px-3 py-1.5',
+  lg: 'text-base px-4 py-2',
+};
+
+export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
+  variant = 'buttons',
+  showIcon = true,
+  size = 'md',
+}) => {
+  const {
+    currentLanguage,
+    changeLanguage,
+    supportedLanguages,
+    languageLabels,
+  } = useLanguage();
+
+  if (variant === 'dropdown') {
+    return (
+      <div className="relative flex items-center gap-2">
+        {showIcon && <Globe className="w-4 h-4 text-toss-grey-500" />}
+        <select
+          value={currentLanguage}
+          onChange={(e) => changeLanguage(e.target.value as typeof currentLanguage)}
+          className={`appearance-none bg-white border border-toss-grey-200 rounded-lg ${sizeClasses[size]} pr-8 font-medium text-toss-grey-700 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer`}
+        >
+          {supportedLanguages.map((lang) => (
+            <option key={lang} value={lang}>
+              {languageLabels[lang]}
+            </option>
+          ))}
+        </select>
+        <div className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none">
+          <svg
+            className="w-4 h-4 text-toss-grey-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {showIcon && <Globe className="w-4 h-4 text-toss-grey-500" />}
+      <div className="flex gap-1.5">
+        {supportedLanguages.map((lang) => (
+          <button
+            key={lang}
+            onClick={() => changeLanguage(lang)}
+            className={`${sizeClasses[size]} font-medium rounded-lg transition-all ${
+              currentLanguage === lang
+                ? 'bg-blue-600 text-white shadow-sm'
+                : 'bg-toss-grey-100 text-toss-grey-600 hover:bg-toss-grey-200 hover:text-toss-grey-900'
+            }`}
+          >
+            {languageLabels[lang]}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Add multi-language support with i18next
- Support Korean (ko), Japanese (ja), and English (en)
- Implement namespace-based translation files

## Changes

### New Components
- `LanguageSelector.tsx` - UI component for language switching
- `LanguageSwitcher.tsx` - Alternative switcher component  
- `I18nProvider.tsx` - Context provider for i18n

### Translation Namespaces
- `common` - Shared UI strings
- `auth` - Authentication related
- `landing` - Landing page content
- `settings` - Settings page
- `glossary` - Stock market glossary
- `nisa` - NISA feature strings

### Configuration
- Add i18next, react-i18next dependencies
- Configure language detection and persistence
- Add useLanguage hook for easy access

## Test Plan
- [ ] Verify language switching works
- [ ] Check all translation files load correctly
- [ ] Test persistence across page refreshes

🤖 Generated with [Claude Code](https://claude.ai/code)