### PR TITLE
👷 ci: Add GitOps auto-update for continuous deployment

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -22,6 +22,7 @@ env:
   REGISTRY: ghcr.io
   BACKEND_IMAGE: ${{ github.repository_owner }}/kabu-agent-backend
   FRONTEND_IMAGE: ${{ github.repository_owner }}/kabu-agent-frontend
+  IMAGE_TAG: ${{ github.sha }}
 
 jobs:
   build-push-backend:
@@ -115,4 +116,45 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  update-gitops:
+    needs: [build-push-backend, build-push-frontend]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
+    steps:
+      - name: Checkout GitOps Repository
+        uses: actions/checkout@v4
+        with:
+          repository: ryokushaka/kabu-agent-gitops
+          token: ${{ secrets.GITOPS_PAT }}
+          path: gitops
+
+      - name: Update image tags in manifests
+        run: |
+          cd gitops
+
+          # Update backend image tag
+          sed -i "s|image: ghcr.io/ryokushaka/kabu-agent-backend:.*|image: ghcr.io/ryokushaka/kabu-agent-backend:${{ env.IMAGE_TAG }}|" \
+            manifests/kabu-agent/backend/deployment.yaml
+
+          # Update frontend image tag
+          sed -i "s|image: ghcr.io/ryokushaka/kabu-agent-frontend:.*|image: ghcr.io/ryokushaka/kabu-agent-frontend:${{ env.IMAGE_TAG }}|" \
+            manifests/kabu-agent/frontend/deployment.yaml
+
+          echo "Updated image tags to: ${{ env.IMAGE_TAG }}"
+
+      - name: Commit and Push changes
+        run: |
+          cd gitops
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "🚀 deploy: Update images to ${{ env.IMAGE_TAG }}"
+            git push
+            echo "Successfully pushed changes to GitOps repository"
+          fi


### PR DESCRIPTION
## Summary
- main 브랜치 머지 후 배포가 자동으로 이루어지지 않는 문제 해결
- `update-gitops` job 추가: 이미지 빌드 완료 후 GitOps 레포의 이미지 태그 자동 업데이트
- ArgoCD가 GitOps 레포 변경을 감지하여 자동 배포 트리거

## Changes
- `.github/workflows/build-push.yml`: GitOps 레포 자동 업데이트 job 추가

## Pipeline Flow
```
main push → build-push-backend + build-push-frontend (parallel)
         → update-gitops (update image tags with commit SHA)
         → ArgoCD detects change → K8s deployment
```

## Required Setup
⚠️ **`GITOPS_PAT` secret 추가 필요**

1. GitHub → Settings → Secrets and variables → Actions
2. New repository secret:
   - Name: `GITOPS_PAT`
   - Value: `ryokushaka/kabu-agent-gitops` 레포에 push 권한이 있는 PAT

## Test plan
- [ ] `GITOPS_PAT` secret 설정 완료
- [ ] PR 머지 후 워크플로우 실행 확인
- [ ] GitOps 레포에 이미지 태그 업데이트 커밋 확인
- [ ] ArgoCD에서 자동 sync 및 배포 확인

🤖 Generated with [Claude Code](https://claude.ai/code)