### PR TITLE
🐛 fix: Use full SHA format for image tags

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}
           tags: |
-            type=sha,prefix=
+            type=sha,prefix=,format=long
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and Push Backend
@@ -101,7 +101,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}
           tags: |
-            type=sha,prefix=
+            type=sha,prefix=,format=long
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and Push Frontend


### PR DESCRIPTION
## Summary
- 이미지 태그 불일치로 인한 배포 실패 수정
- GHCR 이미지 태그와 GitOps deployment 태그 형식 통일

## Problem
| 위치 | 이전 형식 | 예시 |
|------|----------|------|
| GHCR | 짧은 SHA (7자리) | `3911f23` |
| GitOps | 전체 SHA (40자리) | `3911f23c391a...` |

→ K8s에서 이미지를 찾을 수 없어 `ErrImagePull` 발생

## Solution
`docker/metadata-action`에 `format=long` 옵션 추가하여 전체 SHA 사용

## Test plan
- [ ] PR 머지 후 워크플로우 수동 실행
- [ ] GHCR에 전체 SHA 태그로 이미지 푸시 확인
- [ ] GitOps 레포에 동일한 태그로 업데이트 확인
- [ ] ArgoCD 배포 성공 확인

🤖 Generated with [Claude Code](https://claude.ai/code)