### PR TITLE
🐛 fix: Improve news summary error handling

### DIFF
--- a/src/api/public_routes.py
+++ b/src/api/public_routes.py
@@ -84,13 +84,27 @@ async def get_market_news(
 
             # AI 요약 생성 (최신 5개 뉴스)
             top_news = news_items[:5]
+            summary_text = None
+
             if top_news:
-                summary_text = await ai_service.summarize_news([
-                    {"title": n.title, "snippet": n.summary or "", "link": n.content_url}
-                    for n in top_news
-                ])
-            else:
-                summary_text = "뉴스 데이터가 아직 수집되지 않았습니다."
+                try:
+                    summary_text = await ai_service.summarize_news([
+                        {"title": n.title, "snippet": n.summary or "", "link": n.content_url}
+                        for n in top_news
+                    ])
+                except Exception as e:
+                    logger.warning(f"AI summary generation failed: {e}")
+                    summary_text = None
+
+            # 폴백 메시지 설정
+            if not summary_text:
+                if top_news:
+                    # 뉴스는 있지만 AI 요약 실패 시 - 뉴스 제목들로 대체
+                    summary_text = "### 📰 오늘의 주요 뉴스\n\n" + "\n".join([
+                        f"• **{n.title}**" for n in top_news
+                    ])
+                else:
+                    summary_text = "뉴스 데이터가 아직 수집되지 않았습니다."
 
             result = {
                 "summary": summary_text,

--- a/src/services/ai_service.py
+++ b/src/services/ai_service.py
@@ -202,7 +202,7 @@ class GeminiService:
                 redis_client.set(cache_key, response.text, expire=7200)
                 return response.text
             else:
-                return "뉴스 요약 생성 실패"
+                return None
         except Exception as e:
             logger.error(f"Error summarizing news: {e}")
-            return f"뉴스 요약 중 오류 발생: {str(e)}"
+            return None


### PR DESCRIPTION
## Summary
- AI 뉴스 요약 실패 시 에러 메시지가 사용자에게 노출되는 문제 수정
- API key 오류 등 내부 에러를 숨기고 graceful fallback 제공

## Changes
- `ai_service.py`: 에러 발생 시 에러 메시지 대신 `None` 반환
- `public_routes.py`: AI 요약 실패 시 뉴스 제목 목록으로 폴백

## Before
```
뉴스 요약 중 오류 발생: 400 API key not valid...
```

## After
```
### 📰 오늘의 주요 뉴스

• **뉴스 제목 1**
• **뉴스 제목 2**
...
```

## Test plan
- [ ] API key 없이 뉴스 요약 시 폴백 메시지 표시 확인
- [ ] API key 있을 때 정상 요약 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)