### PR TITLE
📝 docs: Add multilingual README documentation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,212 @@
+# Kabu Agent - Overseas Stock Portfolio Management System
+
+Real-time US stock portfolio tracking and AI-powered analysis service using Korea Investment & Securities (KIS) Open API.
+
+## Key Features
+
+### Home (Dashboard)
+Provides total asset overview and AI news briefing.
+![Dashboard](docs/images/dashboard.png)
+
+- Real-time display of total assets (USD/KRW), P&L, and returns
+- Asset trend graph (1 month/3 months/1 year/all)
+- AI news briefing (Korean summary powered by Gemini AI)
+
+### My Stocks (Portfolio)
+Manages detailed holdings information and performance.
+![Portfolio](docs/images/portfolio.png)
+
+- Quantity, average price, current price, unrealized P&L, and returns per stock
+- Automatic sector classification (Technology, Financials, etc.)
+- Excel export (.xlsx)
+
+### Asset Analysis
+Provides portfolio health assessment and AI diagnosis.
+![Analysis](docs/images/analysis.png)
+
+- Sector weight analysis (pie chart)
+- Return contribution analysis
+- AI portfolio diagnosis (risk analysis + rebalancing suggestions)
+
+### Admin Console
+System operations and monitoring tools.
+![Admin](docs/images/admin.png)
+
+- System status monitoring (KIS API, DB, Redis)
+- User management (account status, permissions)
+- API usage statistics
+
+---
+
+## Tech Stack
+
+### Frontend
+| Technology | Version | Purpose |
+|------------|---------|---------|
+| React | 19.2 | UI library |
+| TypeScript | 5.8 | Type safety |
+| Vite | 6.2 | Build tool |
+| TanStack Query | 5.x | Server state management |
+| React Router | 7.9 | Client-side routing |
+| TailwindCSS | 4.x | Styling (Toss design system) |
+| Recharts | 3.5 | Charts |
+| Lucide React | 0.554 | Icons |
+| i18next | 25.x | Internationalization (KO/EN/JA) |
+
+### Backend
+| Technology | Version | Purpose |
+|------------|---------|---------|
+| FastAPI | 0.109 | Web framework |
+| Python | 3.11 | Runtime |
+| PostgreSQL | 15 | Database |
+| Redis | 7 | Cache (tokens, data) |
+| SQLAlchemy | 2.0 | ORM |
+| Google Gemini | Pro | AI analysis |
+| KIS Open API | - | Securities data |
+
+### DevOps & Observability
+| Technology | Purpose |
+|------------|---------|
+| Docker, Docker Compose | Containerization |
+| Nginx | Reverse proxy, Brotli compression |
+| GitHub Actions | CI/CD |
+| ArgoCD | GitOps deployment |
+| Prometheus | Metrics collection |
+| Grafana | Dashboards |
+| OpenTelemetry | Distributed tracing |
+| Jaeger | Tracing visualization |
+
+---
+
+## Installation & Running
+
+### 1. Environment Variables Setup
+
+```bash
+cp .env.example .env
+```
+
+Set the following values in `.env` file:
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `DATABASE_URL` | PostgreSQL connection URL | Yes |
+| `REDIS_URL` | Redis connection URL | Yes |
+| `KIS_APP_KEY` | Korea Investment Securities App Key | Yes |
+| `KIS_APP_SECRET` | Korea Investment Securities App Secret | Yes |
+| `KIS_ACCOUNT_NUMBER` | Account number (8 digits-2 digits) | Yes |
+| `GEMINI_API_KEY` | Google Gemini API Key | Yes |
+| `JWT_SECRET_KEY` | JWT signing key | Yes |
+| `VITE_API_BASE_URL` | Frontend API URL (Docker: leave empty) | No |
+
+### 2. Run with Docker
+
+```bash
+docker-compose up --build
+```
+
+| Service | URL |
+|---------|-----|
+| Frontend | http://localhost:3000 |
+| Backend API | http://localhost:8000 |
+| API Docs | http://localhost:8000/docs |
+
+### 3. Local Development (Without Docker)
+
+```bash
+# Frontend
+npm install
+npm run dev
+
+# Backend
+pip install -r requirements.txt
+uvicorn src.main:app --reload
+```
+
+### 4. Testing
+
+```bash
+# Frontend tests
+npm run test           # Watch mode
+npm run test:run       # Single run
+npm run test:coverage  # With coverage
+
+# Backend tests
+pytest
+```
+
+---
+
+## Project Structure
+
+```
+kabu-agent/
+├── src/
+│   ├── app/                  # App entry point, router, providers
+│   │   ├── providers/        # QueryProvider, AuthProvider
+│   │   └── router/           # AppRouter, ProtectedRoute
+│   │
+│   ├── pages/                # Page components (per route)
+│   │   ├── dashboard/        # Home (dashboard)
+│   │   ├── portfolio/        # My stocks
+│   │   ├── analysis/         # Asset analysis
+│   │   ├── admin/            # Admin
+│   │   ├── settings/         # Settings
+│   │   ├── login/            # Login
+│   │   └── landing/          # Landing page
+│   │
+│   ├── features/             # Feature modules
+│   │   ├── auth/             # Authentication (api, model, hooks)
+│   │   ├── portfolio/        # Portfolio queries
+│   │   ├── analysis/         # Analysis features
+│   │   ├── ai-analysis/      # AI analysis
+│   │   ├── exchange-rate/    # Exchange rates
+│   │   └── glossary/         # Glossary
+│   │
+│   ├── entities/             # Domain entities
+│   │   ├── stock/            # Stock (api, model, ui)
+│   │   ├── user/             # User
+│   │   └── news/             # News
+│   │
+│   ├── widgets/              # Composite UI blocks
+│   │   ├── app-layout/       # App layout
+│   │   ├── header/           # Header
+│   │   └── sidebar/          # Sidebar
+│   │
+│   ├── shared/               # Shared modules
+│   │   ├── api/              # API client
+│   │   ├── ui/               # Common UI components
+│   │   ├── lib/              # Utility functions
+│   │   ├── types/            # Common types
+│   │   └── config/           # Configuration
+│   │
+│   ├── api/                  # Backend API Routes (Python)
+│   ├── services/             # Backend Services
+│   ├── database/             # DB connection
+│   ├── cache/                # Redis cache
+│   └── kis_api.py            # KIS Open API client
+│
+├── docs/                     # Documentation
+├── infra/                    # Infrastructure config (Terraform, etc.)
+├── init-db/                  # DB initialization scripts
+├── nginx/                    # Nginx configuration
+├── tests/                    # Test code
+└── docker-compose.yml        # Docker configuration
+```
+
+**Architecture**: Implements Feature-Sliced Design (FSD) pattern for separation of concerns and modularization.
+
+---
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Frontend Architecture](docs/FRONTEND_ARCHITECTURE.md) | FSD structure, data flow, usage patterns |
+| [System Requirements](docs/system-requirements.md) | Functional & non-functional requirements |
+
+---
+
+## License
+
+MIT License

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,212 @@
+# Kabu Agent - 海外株式ポートフォリオ管理システム
+
+韓国投資証券(KIS) Open APIを活用した米国株式ポートフォリオのリアルタイム照会およびAI分析サービスです。
+
+## 主要機能
+
+### ホーム (ダッシュボード)
+総資産状況とAIニュースブリーフィングを提供します。
+![Dashboard](docs/images/dashboard.png)
+
+- 総資産(USD/KRW)、損益、収益率のリアルタイム表示
+- 資産推移グラフ (1ヶ月/3ヶ月/1年/全期間)
+- AIニュースブリーフィング (Gemini AI基盤の韓国語要約)
+
+### マイ株式 (ポートフォリオ)
+保有銘柄の詳細情報とパフォーマンスを管理します。
+![Portfolio](docs/images/portfolio.png)
+
+- 銘柄別数量、平均取得価格、現在価格、評価損益、収益率
+- セクター自動分類 (Technology, Financials など)
+- Excelエクスポート (.xlsx)
+
+### 資産分析
+ポートフォリオの健全性評価とAI診断を提供します。
+![Analysis](docs/images/analysis.png)
+
+- セクター比重分析 (パイチャート)
+- 収益率貢献度分析
+- AIポートフォリオ診断 (リスク分析 + リバランス提案)
+
+### 管理者コンソール
+システム運用およびモニタリングツールです。
+![Admin](docs/images/admin.png)
+
+- システム状態モニタリング (KIS API, DB, Redis)
+- ユーザー管理 (アカウント状態、権限)
+- API使用量統計
+
+---
+
+## 技術スタック
+
+### フロントエンド
+| 技術 | バージョン | 用途 |
+|-----|-----------|------|
+| React | 19.2 | UIライブラリ |
+| TypeScript | 5.8 | 型安全性 |
+| Vite | 6.2 | ビルドツール |
+| TanStack Query | 5.x | サーバー状態管理 |
+| React Router | 7.9 | クライアントルーティング |
+| TailwindCSS | 4.x | スタイリング (Tossデザインシステム) |
+| Recharts | 3.5 | チャート |
+| Lucide React | 0.554 | アイコン |
+| i18next | 25.x | 多言語対応 (韓/英/日) |
+
+### バックエンド
+| 技術 | バージョン | 用途 |
+|-----|-----------|------|
+| FastAPI | 0.109 | Webフレームワーク |
+| Python | 3.11 | ランタイム |
+| PostgreSQL | 15 | データベース |
+| Redis | 7 | キャッシュ (トークン、データ) |
+| SQLAlchemy | 2.0 | ORM |
+| Google Gemini | Pro | AI分析 |
+| KIS Open API | - | 証券データ |
+
+### DevOps & オブザーバビリティ
+| 技術 | 用途 |
+|-----|------|
+| Docker, Docker Compose | コンテナ化 |
+| Nginx | リバースプロキシ、Brotli圧縮 |
+| GitHub Actions | CI/CD |
+| ArgoCD | GitOpsデプロイ |
+| Prometheus | メトリクス収集 |
+| Grafana | ダッシュボード |
+| OpenTelemetry | 分散トレーシング |
+| Jaeger | トレーシング可視化 |
+
+---
+
+## インストール & 実行
+
+### 1. 環境変数設定
+
+```bash
+cp .env.example .env
+```
+
+`.env`ファイルに以下の値を設定:
+
+| 変数名 | 説明 | 必須 |
+|-------|------|------|
+| `DATABASE_URL` | PostgreSQL接続URL | O |
+| `REDIS_URL` | Redis接続URL | O |
+| `KIS_APP_KEY` | 韓国投資証券 App Key | O |
+| `KIS_APP_SECRET` | 韓国投資証券 App Secret | O |
+| `KIS_ACCOUNT_NUMBER` | 口座番号 (8桁-2桁) | O |
+| `GEMINI_API_KEY` | Google Gemini API Key | O |
+| `JWT_SECRET_KEY` | JWT署名キー | O |
+| `VITE_API_BASE_URL` | フロントエンドAPI URL (Docker: 空欄) | - |
+
+### 2. Docker実行
+
+```bash
+docker-compose up --build
+```
+
+| サービス | URL |
+|---------|-----|
+| フロントエンド | http://localhost:3000 |
+| バックエンドAPI | http://localhost:8000 |
+| APIドキュメント | http://localhost:8000/docs |
+
+### 3. ローカル開発 (Dockerなし)
+
+```bash
+# フロントエンド
+npm install
+npm run dev
+
+# バックエンド
+pip install -r requirements.txt
+uvicorn src.main:app --reload
+```
+
+### 4. テスト
+
+```bash
+# フロントエンドテスト
+npm run test           # Watchモード
+npm run test:run       # 単発実行
+npm run test:coverage  # カバレッジ付き
+
+# バックエンドテスト
+pytest
+```
+
+---
+
+## プロジェクト構造
+
+```
+kabu-agent/
+├── src/
+│   ├── app/                  # アプリエントリーポイント、ルーター、プロバイダー
+│   │   ├── providers/        # QueryProvider, AuthProvider
+│   │   └── router/           # AppRouter, ProtectedRoute
+│   │
+│   ├── pages/                # ページコンポーネント (ルート単位)
+│   │   ├── dashboard/        # ホーム (ダッシュボード)
+│   │   ├── portfolio/        # マイ株式
+│   │   ├── analysis/         # 資産分析
+│   │   ├── admin/            # 管理者
+│   │   ├── settings/         # 設定
+│   │   ├── login/            # ログイン
+│   │   └── landing/          # ランディングページ
+│   │
+│   ├── features/             # 機能単位モジュール
+│   │   ├── auth/             # 認証 (api, model, hooks)
+│   │   ├── portfolio/        # ポートフォリオ照会
+│   │   ├── analysis/         # 分析機能
+│   │   ├── ai-analysis/      # AI分析
+│   │   ├── exchange-rate/    # 為替レート
+│   │   └── glossary/         # 用語辞典
+│   │
+│   ├── entities/             # ドメインエンティティ
+│   │   ├── stock/            # 株式 (api, model, ui)
+│   │   ├── user/             # ユーザー
+│   │   └── news/             # ニュース
+│   │
+│   ├── widgets/              # 複合UIブロック
+│   │   ├── app-layout/       # アプリレイアウト
+│   │   ├── header/           # ヘッダー
+│   │   └── sidebar/          # サイドバー
+│   │
+│   ├── shared/               # 共有モジュール
+│   │   ├── api/              # APIクライアント
+│   │   ├── ui/               # 共通UIコンポーネント
+│   │   ├── lib/              # ユーティリティ関数
+│   │   ├── types/            # 共通型
+│   │   └── config/           # 設定
+│   │
+│   ├── api/                  # バックエンドAPIルート (Python)
+│   ├── services/             # バックエンドサービス
+│   ├── database/             # DB接続
+│   ├── cache/                # Redisキャッシュ
+│   └── kis_api.py            # KIS Open APIクライアント
+│
+├── docs/                     # ドキュメント
+├── infra/                    # インフラ設定 (Terraform等)
+├── init-db/                  # DB初期化スクリプト
+├── nginx/                    # Nginx設定
+├── tests/                    # テストコード
+└── docker-compose.yml        # Docker構成
+```
+
+**アーキテクチャ**: Feature-Sliced Design (FSD)パターンを適用し、関心の分離とモジュール化を実現しています。
+
+---
+
+## ドキュメント
+
+| ドキュメント | 説明 |
+|------------|------|
+| [フロントエンドアーキテクチャ](docs/FRONTEND_ARCHITECTURE.md) | FSD構造、データフロー、使用パターン |
+| [システム要件](docs/system-requirements.md) | 機能要件、非機能要件 |
+
+---
+
+## ライセンス
+
+MIT License

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 ### Frontend
 | 기술 | 버전 | 용도 |
 |-----|------|------|
-| React | 19 | UI 라이브러리 |
+| React | 19.2 | UI 라이브러리 |
 | TypeScript | 5.8 | 타입 안전성 |
 | Vite | 6.2 | 빌드 도구 |
 | TanStack Query | 5.x | 서버 상태 관리 |
@@ -51,21 +51,30 @@
 | TailwindCSS | 4.x | 스타일링 (Toss 디자인 시스템) |
 | Recharts | 3.5 | 차트 |
 | Lucide React | 0.554 | 아이콘 |
+| i18next | 25.x | 다국어 지원 (한/영/일) |
 
 ### Backend
 | 기술 | 버전 | 용도 |
 |-----|------|------|
-| FastAPI | - | 웹 프레임워크 |
+| FastAPI | 0.109 | 웹 프레임워크 |
 | Python | 3.11 | 런타임 |
 | PostgreSQL | 15 | 데이터베이스 |
 | Redis | 7 | 캐시 (토큰, 데이터) |
+| SQLAlchemy | 2.0 | ORM |
 | Google Gemini | Pro | AI 분석 |
 | KIS Open API | - | 증권 데이터 |
 
-### DevOps
-- Docker, Docker Compose
-- Nginx (Reverse Proxy, Brotli 압축)
-- GitHub Actions (CI/CD)
+### DevOps & Observability
+| 기술 | 용도 |
+|-----|------|
+| Docker, Docker Compose | 컨테이너화 |
+| Nginx | Reverse Proxy, Brotli 압축 |
+| GitHub Actions | CI/CD |
+| ArgoCD | GitOps 배포 |
+| Prometheus | 메트릭 수집 |
+| Grafana | 대시보드 |
+| OpenTelemetry | 분산 추적 |
+| Jaeger | 트레이싱 시각화 |
 
 ---
 
@@ -112,6 +121,18 @@ npm run dev
 # Backend
 pip install -r requirements.txt
 uvicorn src.main:app --reload
+```
+
+### 4. 테스트
+
+```bash
+# Frontend 테스트
+npm run test           # Watch 모드
+npm run test:run       # 단일 실행
+npm run test:coverage  # 커버리지 포함
+
+# Backend 테스트
+pytest
 ```
 
 ---
@@ -166,8 +187,10 @@ kabu-agent/
 │   └── kis_api.py            # KIS Open API 클라이언트
 │
 ├── docs/                     # 문서
+├── infra/                    # 인프라 설정 (Terraform 등)
 ├── init-db/                  # DB 초기화 스크립트
 ├── nginx/                    # Nginx 설정
+├── tests/                    # 테스트 코드
 └── docker-compose.yml        # Docker 구성
 ```
 


### PR DESCRIPTION
## Summary
- Update README.md with latest tech stack versions and features
- Add README.en.md (English version)
- Add README.ja.md (Japanese version)
- Document DevOps & Observability tools

## Changes
- `README.md`: Updated Korean documentation with current tech stack
- `README.en.md`: New English documentation
- `README.ja.md`: New Japanese documentation

## Key Updates
- React 19.2, i18next for internationalization
- SQLAlchemy 2.0 ORM
- DevOps section: ArgoCD, Prometheus, Grafana, OpenTelemetry, Jaeger
- Test commands documentation
- Project structure updates (infra/, tests/)

## Test plan
- [x] Verify all markdown files render correctly
- [x] Check version numbers match package.json/requirements.txt

🤖 Generated with [Claude Code](https://claude.ai/code)